### PR TITLE
Fix SSE JSON parsing by ensuring newline separation

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -203,7 +203,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 	}
 }
 
-func (s *MCPServer) ServeSSE(addr string) *server.SSEServer {
+func (s *MCPServer) ServeSSE(addr string) *PatchedSSEServer {
 	s.logger.Info("Creating SSE server",
 		zap.String("context", "console"),
 		zap.String("version", version.Version),
@@ -211,7 +211,8 @@ func (s *MCPServer) ServeSSE(addr string) *server.SSEServer {
 		zap.String("commit_hash", version.CommitHash),
 		zap.String("address", addr),
 	)
-	return server.NewSSEServer(s.server,
+
+	sseServer := server.NewSSEServer(s.server,
 		server.WithBaseURL(fmt.Sprintf("http://%s", addr)),
 		server.WithSSEContextFunc(func(ctx context.Context, r *http.Request) context.Context {
 			ctx = auth.AuthFromRequest(s.logger)(ctx, r)
@@ -219,6 +220,8 @@ func (s *MCPServer) ServeSSE(addr string) *server.SSEServer {
 			return ctx
 		}),
 	)
+
+	return NewPatchedSSEServer(sseServer, s.logger)
 }
 
 func (s *MCPServer) ServeStdio() error {

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"go.uber.org/zap"
+)
+
+// PatchedSSEServer is a wrapper around an http.Handler that fixes the JSON output for SSE.
+type PatchedSSEServer struct {
+	handler http.Handler
+	logger  *zap.Logger
+}
+
+// NewPatchedSSEServer creates a new PatchedSSEServer.
+func NewPatchedSSEServer(handler http.Handler, logger *zap.Logger) *PatchedSSEServer {
+	return &PatchedSSEServer{
+		handler: handler,
+		logger:  logger,
+	}
+}
+
+// Start starts the patched SSE server.
+func (s *PatchedSSEServer) Start(addr string) error {
+	s.logger.Info("Starting patched SSE server", zap.String("address", addr))
+	return http.ListenAndServe(addr, s)
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (s *PatchedSSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	recorder := httptest.NewRecorder()
+	s.handler.ServeHTTP(recorder, r)
+
+	for k, v := range recorder.Header() {
+		w.Header()[k] = v
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(recorder.Code)
+
+	decoder := json.NewDecoder(recorder.Body)
+	for decoder.More() {
+		var v interface{}
+		if err := decoder.Decode(&v); err != nil {
+			s.logger.Error("Error decoding JSON from buffer", zap.Error(err))
+			return
+		}
+
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			s.logger.Error("Error marshalling JSON", zap.Error(err))
+			return
+		}
+
+		fmt.Fprintf(w, "data: %s\n\n", string(jsonBytes))
+	}
+
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}


### PR DESCRIPTION
The MCP client was failing with a JSON parsing error (`Unexpected non-whitespace character after JSON`) when using the SSE transport. This was caused by the SSE server sending a stream of JSON objects without proper delimiters.

This change introduces a wrapper around the SSE handler that intercepts the raw JSON output and formats it into a compliant Server-Sent Events stream. Each JSON object is now sent as a separate `data:` message, separated by double newlines.

This is a workaround for an issue in the upstream `mcp-go` library, which cannot be modified directly.

The changes are:
- Add `pkg/server/sse.go` with a `PatchedSSEServer` that wraps the original SSE handler.
- Modify `pkg/server/server.go` to use the `PatchedSSEServer`.